### PR TITLE
Waiting for connections

### DIFF
--- a/src/converters.rs
+++ b/src/converters.rs
@@ -15,8 +15,6 @@ pub trait Converter {
         event: &hawktracer_parser::Event,
         reg: &hawktracer_parser::EventKlassRegistry,
     ) -> Result<(), Box<std::error::Error>>;
-
-    fn close_converter(&mut self) {}
 }
 
 pub trait ConverterFactory {

--- a/src/converters/chrome_tracing_converter.rs
+++ b/src/converters/chrome_tracing_converter.rs
@@ -36,7 +36,7 @@ impl std::fmt::Display for EventProcessingError {
 
 impl std::error::Error for EventProcessingError {}
 
-impl<'a> Converter for ChromeTracingConverter {
+impl Converter for ChromeTracingConverter {
     fn process_event(
         &mut self,
         event: &Event,
@@ -72,7 +72,7 @@ impl<'a> Converter for ChromeTracingConverter {
     }
 }
 
-impl<'a> ChromeTracingConverter {
+impl ChromeTracingConverter {
     pub fn new(writable: Box<std::io::Write>, label_getter: LabelGetter) -> ChromeTracingConverter {
         ChromeTracingConverter {
             writable,

--- a/src/converters/flamegraph_converter.rs
+++ b/src/converters/flamegraph_converter.rs
@@ -154,7 +154,7 @@ impl FlamegraphConverter {
     }
 }
 
-impl<'a> Converter for FlamegraphConverter {
+impl Converter for FlamegraphConverter {
     fn process_event(
         &mut self,
         event: &hawktracer_parser::Event,
@@ -180,9 +180,11 @@ impl<'a> Converter for FlamegraphConverter {
 
         Ok(())
     }
+}
 
-    fn close_converter(&mut self) {
-        self.generate_flamegraph()
+impl Drop for FlamegraphConverter {
+    fn drop(&mut self) {
+        self.generate_flamegraph();
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,6 +147,4 @@ fn main() {
             }
         }
     }
-
-    converter.close_converter();
 }


### PR DESCRIPTION
We will wait for connections now instead of having to start the converter after the program we profile.

Pushed by mistake on this same branch some unrelated things:
- Removed close_converter since it could be replaced with Drop trait safely for the current use. Maybe in the future it can be renamed to something else if needed (only Flamegraph used it anyway).
- Removed some not needed lifetimes specifications